### PR TITLE
Fix: "Wesh" spelling and copyright year

### DIFF
--- a/pages/components/Footer/Footer.tsx
+++ b/pages/components/Footer/Footer.tsx
@@ -6,7 +6,7 @@ const Footer = () => {
         <img className={styles.logo} src="./img/NavBarLogo.png" alt="" />
         {/*<img src="../../img/Footer.png" alt="" />*/}
         <p>
-          WESH Network is an open source wild & asynchronous mesh network
+          Wesh Network is an open source wild & asynchronous mesh network
           protocol powered by Berty Technologies’ non-profit organisation.
         </p>
       </div>

--- a/pages/components/Navbar/Navbar.tsx
+++ b/pages/components/Navbar/Navbar.tsx
@@ -51,7 +51,7 @@ const Navbar = () => {
           </a>
         </div>
         <div className={styles.credits}>
-          <p>Copyright © 2022 – Berty.Tech non-profit organization</p>
+          <p>Copyright © 2023 – Berty.Tech non-profit organization</p>
           <div>
             <img src="./img/Telegram.png" alt="" />
             <img src="./img/Twitter.png" alt="" />

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -25,7 +25,7 @@ export default function Home() {
           <div className={styles.MainTitle}>
             <div>
               <h1>Async mesh network protocol</h1>
-              <h3>With wesh&apos;s toolkit, building p2p apps has never been simpler</h3>
+              <h3>With Wesh&apos;s toolkit, building p2p apps has never been simpler</h3>
               <p>Wesh network is a decentralized extreme communication protocol</p>
               <Button
                 text="Get Started"

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -317,7 +317,7 @@ export default function Home() {
         */}
         <Footer />
         <div className={styles.credits}>
-          <p>Copyright © 2022 – Berty.Tech non-profit organization</p>
+          <p>Copyright © 2023 – Berty.Tech non-profit organization</p>
           <div>
             {/* <img src="./img/Telegram.png" alt="" /> */ }
             {/* <img src="./img/Twitter.png" alt="" /> */ }


### PR DESCRIPTION
Small changes: Change "WESH" to Wesh" for consistency. Change the copyright year to 2023.