### PR TITLE
fix: Use the semantic URL to link to the previous blog post

### DIFF
--- a/pages/posts/wesh-app-with-persistent-storage.tsx
+++ b/pages/posts/wesh-app-with-persistent-storage.tsx
@@ -36,7 +36,7 @@ export default function Post() {
                 <h2>{posts.title}</h2>
                 <p>
                   In the
-                  <a href="https://wesh.network/posts/2" target="_blank" rel="noreferrer">
+                  <a href="https://wesh.network/posts/wesh-hello-world-app" target="_blank" rel="noreferrer">
                     &nbsp;previous blog post
                   </a>
                   , we made an example “Hello world” app using the Wesh API. But it used in-memory storage for the keys and messages, which are lost when the app closes. It&apos;s

--- a/pages/posts/wesh-hello-world-app.tsx
+++ b/pages/posts/wesh-hello-world-app.tsx
@@ -36,7 +36,7 @@ export default function Post() {
                 <h2>{posts.title}</h2>
                 <p>
                   Now that you have been introduced to Wesh in the
-                  <a href="https://wesh.network/posts/1" target="_blank" rel="noreferrer"> previous blog post</a>, it’s time to explore the code. We will write a “Hello World” app, similar to the
+                  <a href="https://wesh.network/posts/introducing-the-wesh-network-toolkit" target="_blank" rel="noreferrer"> previous blog post</a>, it’s time to explore the code. We will write a “Hello World” app, similar to the
                   <a href="https://go.dev/doc/tutorial/getting-started" target="_blank" rel="noreferrer"> Go tutorial </a>
                   which you can read to set up Go on your computer and for other details. (This has been tested with Go 1.19 on macOS and Ubuntu.) This example app will connect to
                   the Wesh service and call a function. When finished, you will be confident that you can use Wesh on your platform.


### PR DESCRIPTION
This avoids waiting to refresh the page.