### PR TITLE
removed a random , in the blogpost site

### DIFF
--- a/pages/blog.tsx
+++ b/pages/blog.tsx
@@ -36,7 +36,6 @@ export default function Blogpage() {
             ))}
           </div>
         </section>
-        ,
         <Footer />
         <div className={styles.credits}>
           <p>Copyright © 2023 – Berty.Tech non-profit organization</p>


### PR DESCRIPTION
![image](https://github.com/berty/www.wesh.network/assets/38732192/39db758b-aa6a-4da6-8ab7-395148bd4e1a)

removed this `,` that was randomly floating on the blogpost page