### PR TITLE
fix: Update blog examples to weshnet/v2

### DIFF
--- a/pages/posts/share-contact-and-send-message.tsx
+++ b/pages/posts/share-contact-and-send-message.tsx
@@ -64,9 +64,10 @@ import (
 	"os"
 	"time"
 
-	"berty.tech/weshnet"
-	"berty.tech/weshnet/pkg/protocoltypes"
+	"berty.tech/weshnet/v2"
+	"berty.tech/weshnet/v2/pkg/protocoltypes"
 	"github.com/mr-tron/base58"
+	"google.golang.org/protobuf/proto"
   )`}
                   </code>
                 </pre>
@@ -108,7 +109,7 @@ import (
 	// client1 accepts the contact request from client2.
 	_, err = client1.ContactRequestAccept(ctx,
 		&protocoltypes.ContactRequestAccept_Request{
-			ContactPK: request.ContactPK,
+			ContactPk: request.ContactPk,
 		})
 	if err != nil {
 		panic(err)
@@ -116,13 +117,13 @@ import (
 
 	// Activate the contact group.
 	groupInfo, err := client1.GroupInfo(ctx, &protocoltypes.GroupInfo_Request{
-		ContactPK: request.ContactPK,
+		ContactPk: request.ContactPk,
 	})
 	if err != nil {
 		panic(err)
 	}
 	_, err = client1.ActivateGroup(ctx, &protocoltypes.ActivateGroup_Request{
-		GroupPK: groupInfo.Group.PublicKey,
+		GroupPk: groupInfo.Group.PublicKey,
 	})
 	if err != nil {
 		panic(err)
@@ -178,7 +179,7 @@ import (
                 <pre>
                   <code className="language-go">
                     {`func receiveContactRequest(ctx context.Context, client weshnet.ServiceClient) (*protocoltypes.AccountContactRequestIncomingReceived, error) {
-	// Get the client's AccountGroupPK from the configuration.
+	// Get the client's AccountGroupPk from the configuration.
 	config, err := client.ServiceGetConfiguration(ctx, &protocoltypes.ServiceGetConfiguration_Request{})
 	if err != nil {
 		return nil, err
@@ -188,7 +189,7 @@ import (
 	subCtx, subCancel := context.WithCancel(ctx)
 	defer subCancel()
 	subMetadata, err := client.GroupMetadataList(subCtx, &protocoltypes.GroupMetadataList_Request{
-			GroupPK: config.AccountGroupPK,
+			GroupPk: config.AccountGroupPk,
 		})
 	if err != nil {
 		return nil, err
@@ -205,12 +206,12 @@ import (
 		}
 
 		if metadata == nil || metadata.Metadata.EventType !=
-				protocoltypes.EventTypeAccountContactRequestIncomingReceived {
+				protocoltypes.EventType_EventTypeAccountContactRequestIncomingReceived {
 			continue
 		}
 
 		request := &protocoltypes.AccountContactRequestIncomingReceived{}
-		if err = request.Unmarshal(metadata.Event); err != nil {
+		if err = proto.Unmarshal(metadata.Event, request); err != nil {
 			return nil, err
 		}
 
@@ -232,7 +233,7 @@ import (
                   Most API functions return a data structure, but a few like <code>GroupMetadataList</code> return a subscription stream like <code>subMetadata</code>. We use a{" "}
                   <code>for</code> loop and call <code>subMetadata.Recv()</code> which blocks until it receives an event (or end of stream). As you build more complex apps, an
                   event loop like this may handle more event types and operations. For now, we just check that the event type is the one we’re waiting for,{" "}
-                  <code>EventTypeAccountContactRequestIncomingReceived</code>.
+                  <code>EventType_EventTypeAccountContactRequestIncomingReceived</code>.
                 </p>
                 <p>
                   Now we can use <code>Unmarshal</code> to convert the <code>metadata</code> event to the specific <code>AccountContactRequestIncomingReceived</code> event. (
@@ -251,7 +252,7 @@ import (
 	subCtx, subCancel := context.WithCancel(ctx)
 	defer subCancel()
 	subMessages, err := client.GroupMessageList(subCtx, &protocoltypes.GroupMessageList_Request{
-		GroupPK: groupInfo.Group.PublicKey,
+		GroupPk: groupInfo.Group.PublicKey,
 	})
 	if err != nil {
 		panic(err)
@@ -343,13 +344,13 @@ import (
 
 	// Activate the contact group.
 	groupInfo, err := client2.GroupInfo(ctx, &protocoltypes.GroupInfo_Request{
-		ContactPK: contact.Contact.PK,
+		ContactPk: contact.Contact.Pk,
 	})
 	if err != nil {
 		panic(err)
 	}
 	_, err = client2.ActivateGroup(ctx, &protocoltypes.ActivateGroup_Request{
-		GroupPK: groupInfo.Group.PublicKey,
+		GroupPk: groupInfo.Group.PublicKey,
 	})
 	if err != nil {
 		panic(err)
@@ -357,7 +358,7 @@ import (
 
 	// Send a message to the contact group.
 	_, err = client2.AppMessageSend(ctx, &protocoltypes.AppMessageSend_Request{
-		GroupPK: groupInfo.Group.PublicKey,
+		GroupPk: groupInfo.Group.PublicKey,
 		Payload: []byte("Hello"),
 	})
 	if err != nil {
@@ -384,7 +385,7 @@ import (
                 </p>
                 <p>
                   Similar to the code above, client2 needs to activate the Contact group using <code>GroupInfo</code> and <code>ActivateGroup</code>. (In this case, client2 has
-                  client1’s account public key from the shared contact in <code>contact.Contact.PK</code>.)
+                  client1’s account public key from the shared contact in <code>contact.Contact.Pk</code>.)
                 </p>
                 <p>
                   We’re almost done! Client2 calls <code>AppMessageSend</code> (

--- a/pages/posts/wesh-app-with-persistent-storage.tsx
+++ b/pages/posts/wesh-app-with-persistent-storage.tsx
@@ -66,8 +66,8 @@ import (
 	"context"
 	"fmt"
 
-	"berty.tech/weshnet"
-	"berty.tech/weshnet/pkg/protocoltypes"
+	"berty.tech/weshnet/v2"
+	"berty.tech/weshnet/v2/pkg/protocoltypes"
 )`}
                   </code>
                 </pre>
@@ -92,7 +92,7 @@ func main() {
 		panic(err)
 	}
 
-	fmt.Println("Hello, world! My peer ID is", config.PeerID)
+	fmt.Println("Hello, world! My peer ID is", config.PeerId)
 }
 `}
                   </code>

--- a/pages/posts/wesh-hello-world-app.tsx
+++ b/pages/posts/wesh-hello-world-app.tsx
@@ -62,14 +62,14 @@ import (
 	"context"
 	"fmt"
 
-	"berty.tech/weshnet"
-	"berty.tech/weshnet/pkg/protocoltypes"
+	"berty.tech/weshnet/v2"
+	"berty.tech/weshnet/v2/pkg/protocoltypes"
 )`}
                   </code>
                 </pre>
                 <p>
-                  We import <code>fmt</code> as usual in Go code so that we can print a message. We import <code>berty.tech/weshnet</code> so that we can call the Go function to initialize the Wesh service (explained below). Finally, your
-                  app interacts with the Wesh service through gRPC which uses Protobuf messages. Therefore, we import the Wesh API Protobuf types with <code>berty.tech/weshnet/pkg/protocoltypes</code>, and we import <code>context</code> because all of the gRPC calls use a Go context object (explained below).
+                  We import <code>fmt</code> as usual in Go code so that we can print a message. We import <code>berty.tech/weshnet/v2</code> so that we can call the Go function to initialize the Wesh service (explained below). Finally, your
+                  app interacts with the Wesh service through gRPC which uses Protobuf messages. Therefore, we import the Wesh API Protobuf types with <code>berty.tech/weshnet/v2/pkg/protocoltypes</code>, and we import <code>context</code> because all of the gRPC calls use a Go context object (explained below).
                 </p>
                 <p>To complete the example, paste the following main function and save the file.</p>
                 <pre>
@@ -91,7 +91,7 @@ func main() {
 		panic(err)
 	}
 
-	fmt.Println("Hello, world! My peer ID is", config.PeerID)
+	fmt.Println("Hello, world! My peer ID is", config.PeerId)
 }
 `}
                   </code>
@@ -113,7 +113,7 @@ func main() {
                   Finally, we interact with the Wesh service by calling <code>client.ServiceGetConfiguration</code> , passing the <code>ctx</code> that we created.
                   This method gets the current configuration of the service and is <a href="https://buf.build/berty-technologies/weshnet/docs/main:weshnet.protocol.v1#weshnet.protocol.v1.ProtocolService.ServiceGetConfiguration" target="_blank" rel="noreferrer">documented here</a>, along
                   with all the other API calls. Each API call takes a Protobuf request message. In this case there are no parameters, so we create an empty <code>protocoltypes.ServiceGetConfiguration_Request</code>. (We will see more complex examples later.) And each API call returns a Protobuf reply message, or sometimes a stream object. In this case it is a <a href=" https://buf.build/berty-technologies/weshnet/docs/main:weshnet.protocol.v1#weshnet.protocol.v1.ServiceGetConfiguration.Reply" target="_blank" rel="noreferrer">ServiceGetConfiguration.Reply</a>. So to finish, we print a happy message with
-                  the <code>PeerID</code> of the in-memory IPFS node.
+                  the <code>PeerId</code> of the in-memory IPFS node.
                 </p>
                 <p>To see the result, in a terminal enter:</p>
                 <pre>


### PR DESCRIPTION
Update the code in the blog examples to the new weshnet/v2 identifiers.